### PR TITLE
Update the Element ID of the docsend viewer.

### DIFF
--- a/content.js
+++ b/content.js
@@ -2,7 +2,7 @@
 
 function getSlides() {
   try {
-    var viewer = document.getElementById('viewer'),
+    var viewer = document.getElementById('ds-body'),
         slides = viewer.getElementsByClassName('item');
     return slides;
   } catch(e) {


### PR DESCRIPTION
It seems like docsend reworked the element IDs, which breaks the existing version of this scraper. I updated to a new ID and demoed it with a few documents, and it seems to work. This should close issue #3.